### PR TITLE
don't swallow errors during register command

### DIFF
--- a/cli/commands/register.js
+++ b/cli/commands/register.js
@@ -23,8 +23,15 @@ module.exports = function () {
     } else {
       end()
     }
-    function end (err) {
-      return done(err, err ? null : packmule)
+    function end (err, response, body) {
+      if (err) {
+        return done(err)
+      }
+      if (response && response.statusCode >= 400) {
+        err = new Error(body && body.error ? body.error : 'Error registering release')
+        return done(err)
+      }
+      return done(null, packmule)
     }
   })
 }


### PR DESCRIPTION
If the registration endpoint returns an error, the command fails and prints the error.
